### PR TITLE
MR id is now called iid

### DIFF
--- a/src/apis/gitlab/update-mr.js
+++ b/src/apis/gitlab/update-mr.js
@@ -82,7 +82,7 @@ async function updateMR(data, branch, url, gitlabProjectId, apiKey, hasI18nFile)
         if (clearedLabels && clearedLabels.length) {
             client.mergeRequests.update({
                 id: gitlabProjectId,
-                merge_request_id: mr.id,
+                merge_request_id: mr.iid,
                 description: description,
                 labels: clearedLabels.join(',')
             });


### PR DESCRIPTION
The gitlab API has updated the way they return Merge Request data. Each MR now has an id, _and_ an iid. I believe the id is the MR id for all of gitlab, and iid is the repo specific id. When making a call to retrieve a specific MR such as ***/api/v4/projects/999/merge_requests/2717, we need to use the repo specific id to retrieve the correct MR, or a 404 will be given.


